### PR TITLE
Update ShowQuoteViewController.swift

### DIFF
--- a/Paraphrase/ShowQuoteViewController.swift
+++ b/Paraphrase/ShowQuoteViewController.swift
@@ -22,6 +22,7 @@ class ShowQuoteViewController: UIViewController {
         }
 
         title = quote.author
+        view.backgroundColor = .systemBackground // this will adapte to the dark mode
         navigationItem.largeTitleDisplayMode = .never
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(shareQuote))
 


### PR DESCRIPTION
Added view.backgroundColor = .systemBackground to make this detail view adapted to dark. 

Currently when dark mode is on, this view is filled with white background. since label is black color. 
![IMG_96E40A0DD7B6-1](https://github.com/twostraws/Paraphrase/assets/44181523/8dad1b37-3ceb-4d5e-a1e9-a5476b864061)


